### PR TITLE
fix link

### DIFF
--- a/src/events/board-created.md
+++ b/src/events/board-created.md
@@ -13,7 +13,7 @@ defineEmits<{
 }>();
 ```
 
-<p>Full reference of all methods: <a href="/board-api.html">Board API Docs</a> | <a href="https://github.com/qwerty084/vue3-chessboard/blob/main/src/classes/BoardApi.ts">Source Code</a></p>
+<p>Full reference of all methods: <a href="/vue3-chessboard-docs/board-api.html">Board API Docs</a> | <a href="https://github.com/qwerty084/vue3-chessboard/blob/main/src/classes/BoardApi.ts">Source Code</a></p>
 
 ## Example
 


### PR DESCRIPTION
The "Board API Docs" link is 404

<img width="485" alt="image" src="https://github.com/user-attachments/assets/cc5545e7-0ad8-4b9b-8546-77ab0789826b" />
